### PR TITLE
Fix loadImage process to load initial image without clearing with first 

### DIFF
--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -52,6 +52,7 @@ typedef enum {
 
 // get the current drawing
 @property (nonatomic, strong, readonly) UIImage *image;
+@property (nonatomic, strong) UIImage *prev_image;
 @property (nonatomic, readonly) NSUInteger undoSteps;
 
 // load external image

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -107,6 +107,8 @@
         // erase the previous image
         self.image = nil;
         
+        [[self.prev_image copy] drawInRect:self.bounds];
+        
         // I need to redraw all the lines
         for (id<ACEDrawingTool> tool in self.pathArray) {
             [tool draw];
@@ -255,6 +257,9 @@
 - (void)loadImage:(UIImage *)image
 {
     self.image = image;
+    
+    //save the loaded image to persist after an undo step
+    self.prev_image = [image copy];
     
     // when loading an external image, I'm cleaning all the paths and the undo buffer
     [self.bufferArray removeAllObjects];


### PR DESCRIPTION
This should allow users to load an initial image, and then not be cleared if they continue drawing and eventually press the Undo button.
