### PR TITLE
Fix textarea landscape mode ios8

### DIFF
--- a/ACEDrawingView.podspec
+++ b/ACEDrawingView.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
   s.summary      = 'An open source iOS component to create a drawing app.'
   s.homepage     = 'https://github.com/acerbetti/ACEDrawingView'
   s.author       = { 'Stefano Acerbetti' => 'acerbetti@gmail.com' }
-  s.source       = { :git => 'https://github.com/acerbetti/ACEDrawingView.git', :tag => 'v1.3.1' }
+  s.source       = { :git => 'https://github.com/alex-luca/ACEDrawingView.git'}
   s.platform     = :ios, '7.0'
   s.source_files = 'ACEDrawingView/*.{h,m}'
   s.requires_arc = true

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -417,11 +417,15 @@
 
 - (void)keyboardDidShow:(NSNotification *)notification
 {
-    if ( UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation])) {
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
+    [self adjustFramePosition:notification];
+#else
+   if ( UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation])) {
         [self landscapeChanges:notification];
     } else {
-        [self portraitChanges:notification];
+        [self adjustFramePosition:notification];
     }
+#endif
 }
 
 - (void)landscapeChanges:(NSNotification *)notification {
@@ -439,7 +443,7 @@
 
     }
 }
-- (void)portraitChanges:(NSNotification *)notification {
+- (void)adjustFramePosition:(NSNotification *)notification {
     CGPoint textViewBottomPoint = [self convertPoint:self.textView.frame.origin toView:nil];
     textViewBottomPoint.y += self.textView.frame.size.height;
 

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -34,6 +34,7 @@
 
 // experimental code
 #define PARTIAL_REDRAW          0
+#define IOS8_OR_ABOVE [[[UIDevice currentDevice] systemVersion] integerValue] >= 8.0
 
 @interface ACEDrawingView () {
     CGPoint currentPoint;
@@ -417,15 +418,16 @@
 
 - (void)keyboardDidShow:(NSNotification *)notification
 {
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 80000
-    [self adjustFramePosition:notification];
-#else
-   if ( UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation])) {
-        [self landscapeChanges:notification];
-    } else {
+    if (IOS8_OR_ABOVE) {
         [self adjustFramePosition:notification];
     }
-#endif
+    else {
+        if (UIInterfaceOrientationIsLandscape([[UIDevice currentDevice] orientation])) {
+            [self landscapeChanges:notification];
+        } else {
+            [self adjustFramePosition:notification];
+        }
+    }
 }
 
 - (void)landscapeChanges:(NSNotification *)notification {


### PR DESCRIPTION
The issue with the height/width of the screen in landscape mode was fixed in IOS 8, so I added a check for the device version. 