### PR TITLE
Update originalFrameYPos when keyboard is shown. 

### DIFF
--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -425,6 +425,8 @@
 
 - (void)keyboardDidShow:(NSNotification *)notification
 {
+    self.originalFrameYPos = self.frame.origin.y;
+
     if (IOS8_OR_ABOVE) {
         [self adjustFramePosition:notification];
     }


### PR DESCRIPTION
This is to allow ACEDrawingView to be moved at any time and still be able to correctly restore the position when the keyboard is hidden.