### PR TITLE
Rename `prev_image` to `backgroundImage`

### DIFF
--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -53,7 +53,7 @@ typedef enum {
 
 // get the current drawing
 @property (nonatomic, strong, readonly) UIImage *image;
-@property (nonatomic, strong) UIImage *prev_image;
+@property (nonatomic, strong) UIImage *backgroundImage;
 @property (nonatomic, readonly) NSUInteger undoSteps;
 
 // load external image

--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -53,6 +53,7 @@ typedef enum {
 
 // get the current drawing
 @property (nonatomic, strong, readonly) UIImage *image;
+@property (nonatomic, strong) UIImage *prev_image DEPRECATED_MSG_ATTRIBUTE("Use 'backgroundImage' instead.");
 @property (nonatomic, strong) UIImage *backgroundImage;
 @property (nonatomic, readonly) NSUInteger undoSteps;
 

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -82,13 +82,21 @@
     self.lineColor = kDefaultLineColor;
     self.lineWidth = kDefaultLineWidth;
     self.lineAlpha = kDefaultLineAlpha;
-    
+
     // set the transparent background
     self.backgroundColor = [UIColor clearColor];
     
     self.originalFrameYPos = self.frame.origin.y;
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];
+}
+
+- (UIImage *)prev_image {
+    return self.backgroundImage;
+}
+
+- (void)setPrev_image:(UIImage *)prev_image {
+    [self setBackgroundImage:prev_image];
 }
 
 

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -115,7 +115,7 @@
         self.image = nil;
         
         // load previous image (if returning to screen)
-        [[self.prev_image copy] drawInRect:self.bounds];
+        [[self.backgroundImage copy] drawInRect:self.bounds];
         
         // I need to redraw all the lines
         for (id<ACEDrawingTool> tool in self.pathArray) {
@@ -484,7 +484,7 @@
     self.image = image;
     
     //save the loaded image to persist after an undo step
-    self.prev_image = [image copy];
+    self.backgroundImage = [image copy];
     
     // when loading an external image, I'm cleaning all the paths and the undo buffer
     [self.bufferArray removeAllObjects];
@@ -523,7 +523,7 @@
     [self resetTool];
     [self.bufferArray removeAllObjects];
     [self.pathArray removeAllObjects];
-    self.prev_image = nil;
+    self.backgroundImage = nil;
     [self updateCacheImage:YES];
     [self setNeedsDisplay];
 }
@@ -577,7 +577,7 @@
     self.bufferArray = nil;
     self.currentTool = nil;
     self.image = nil;
-    self.prev_image = nil;
+    self.backgroundImage = nil;
     
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardDidShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardDidHideNotification object:nil];


### PR DESCRIPTION
It’s always tricky to rename public properties, but I think this one is worth it. The underscore in `prev_image` isn’t exactly canon, and I find `backgroundImage` to be more explicit. What do you think?

If it sounds good, I would also suggest renaming `pathArray` to `toolsArray`, again to be more explicit about what these properties are managing.