### PR TITLE
Support for resizing

### DIFF
--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -39,6 +39,11 @@ typedef enum {
     ACEDrawingToolTypeMultilineText
 } ACEDrawingToolType;
 
+typedef NS_ENUM(NSUInteger, ACEDrawingMode) {
+    ACEDrawingModeScale,
+    ACEDrawingModeOriginalSize
+};
+
 @protocol ACEDrawingViewDelegate, ACEDrawingTool;
 
 @interface ACEDrawingView : UIView<UITextViewDelegate>
@@ -50,6 +55,7 @@ typedef enum {
 @property (nonatomic, strong) UIColor *lineColor;
 @property (nonatomic, assign) CGFloat lineWidth;
 @property (nonatomic, assign) CGFloat lineAlpha;
+@property (nonatomic, assign) ACEDrawingMode drawMode;
 
 // get the current drawing
 @property (nonatomic, strong, readonly) UIImage *image;
@@ -69,6 +75,12 @@ typedef enum {
 
 - (BOOL)canRedo;
 - (void)redoLatestStep;
+
+/**
+ @discussion Discards the tool stack and renders them to prev_image, making the current state the 'start' state.
+ (Can be called before resize to make content more predictable)
+ */
+- (void)commitAndDiscardToolStack;
 
 @end
 

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -82,6 +82,8 @@
     self.lineColor = kDefaultLineColor;
     self.lineWidth = kDefaultLineWidth;
     self.lineAlpha = kDefaultLineAlpha;
+
+    self.drawMode = ACEDrawingModeOriginalSize;
     
     // set the transparent background
     self.backgroundColor = [UIColor clearColor];
@@ -100,9 +102,22 @@
     // TODO: draw only the updated part of the image
     [self drawPath];
 #else
-    [self.image drawInRect:self.bounds];
+    switch (self.drawMode) {
+        case ACEDrawingModeOriginalSize:
+            [self.image drawAtPoint:CGPointZero];
+            break;
+        case ACEDrawingModeScale:
+            [self.image drawInRect:self.bounds];
+            break;
+    }
     [self.currentTool draw];
 #endif
+}
+
+- (void)commitAndDiscardToolStack {
+    [self updateCacheImage:YES];
+    self.prev_image = self.image;
+    [self.pathArray removeAllObjects];
 }
 
 - (void)updateCacheImage:(BOOL)redraw
@@ -115,7 +130,14 @@
         self.image = nil;
         
         // load previous image (if returning to screen)
-        [[self.prev_image copy] drawInRect:self.bounds];
+        switch (self.drawMode) {
+            case ACEDrawingModeOriginalSize:
+                [[self.prev_image copy] drawAtPoint:CGPointZero];
+                break;
+            case ACEDrawingModeScale:
+                [[self.prev_image copy] drawInRect:self.bounds];
+                break;
+        }
         
         // I need to redraw all the lines
         for (id<ACEDrawingTool> tool in self.pathArray) {


### PR DESCRIPTION
In our application, we sometimes resize the draw zone after it has already been rendered in. This behaves unusually with the default implementation so we added two functions to improve this:

1. The ability to specify that the image should always be drawn at its original size, instead of stretched to match the size of the drawing view
2. The ability to "commit" all tools, so that they behave as we expect during resizing (instead of tools that were drawn outside the frame coming back, etc.)

Our behaviour with these changes:
![44f892bc-8cf1-40d2-b40f-8e3e356b90a0-17531-000008df57d5c7dd](https://cloud.githubusercontent.com/assets/1508976/7967761/6f9b953a-09e9-11e5-92e5-b7e0af762e06.gif) 