### PR TITLE
Allow specification of font for TextTool and MultilineTextTool

### DIFF
--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -58,6 +58,7 @@ typedef NS_ENUM(NSUInteger, ACEDrawingMode) {
 @property (nonatomic, strong) UIColor *lineColor;
 @property (nonatomic, assign) CGFloat lineWidth;
 @property (nonatomic, assign) CGFloat lineAlpha;
+@property (nonatomic, strong) NSString *fontName;
 @property (nonatomic, assign) ACEDrawingMode drawMode;
 
 // get the current drawing

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -368,7 +368,11 @@
     
     int calculatedFontSize = self.lineWidth * 3; //3 is an approximate size factor
     
-    [self.textView setFont:[UIFont systemFontOfSize:calculatedFontSize]];
+    if(self.fontName != nil) {
+        [self.textView setFont:[UIFont fontWithName:self.fontName size:calculatedFontSize]];
+    } else {
+        [self.textView setFont:[UIFont systemFontOfSize:calculatedFontSize]];
+    }
     self.textView.textColor = self.lineColor;
     self.textView.alpha = self.lineAlpha;
     


### PR DESCRIPTION
I wanted to offer both a serif (Georgia) and sans (System default) option in my app - was a pretty straightforward change.