### PR TITLE
Optional edgeSnapThreshold to snap RectangleTool to edges of view

### DIFF
--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSUInteger, ACEDrawingMode) {
 @property (nonatomic, assign) CGFloat lineWidth;
 @property (nonatomic, assign) CGFloat lineAlpha;
 @property (nonatomic, strong) NSString *fontName;
+@property (nonatomic, assign) CGFloat edgeSnapThreshold;
 @property (nonatomic, assign) ACEDrawingMode drawMode;
 
 // get the current drawing

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -354,6 +354,17 @@
     [self touchesEnded:touches withEvent:event];
 }
 
+- (void) snapCurrentPointToEdges
+{
+    int xMax = self.frame.size.width;
+    int yMax = self.frame.size.height;
+    
+    if(currentPoint.x < self.edgeSnapThreshold) currentPoint.x = 0;
+    else if(currentPoint.x > xMax - self.edgeSnapThreshold) currentPoint.x = xMax;
+    if(currentPoint.y < self.edgeSnapThreshold) currentPoint.y = 0;
+    else if(currentPoint.y > yMax - self.edgeSnapThreshold) currentPoint.y = yMax;
+}
+
 #pragma mark - Text Entry
 
 - (void)initializeTextBox:(CGPoint)startingPoint WithMultiline:(BOOL)multiline {

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -281,6 +281,10 @@
     self.currentTool.lineColor = self.lineColor;
     self.currentTool.lineAlpha = self.lineAlpha;
     
+    if (self.edgeSnapThreshold > 0 && [self.currentTool isKindOfClass:[ACEDrawingRectangleTool class]]) {
+        [self snapCurrentPointToEdges];
+    }
+    
     if ([self.currentTool class] == [ACEDrawingTextTool class]) {
         [self initializeTextBox:currentPoint WithMultiline:NO];
     } else if([self.currentTool class] == [ACEDrawingMultilineTextTool class]) {
@@ -305,6 +309,10 @@
     previousPoint2 = previousPoint1;
     previousPoint1 = [touch previousLocationInView:self];
     currentPoint = [touch locationInView:self];
+    
+    if (self.edgeSnapThreshold > 0 && [self.currentTool isKindOfClass:[ACEDrawingRectangleTool class]]) {
+        [self snapCurrentPointToEdges];
+    }
     
     if ([self.currentTool isKindOfClass:[ACEDrawingPenTool class]]) {
         CGRect bounds = [(ACEDrawingPenTool*)self.currentTool addPathPreviousPreviousPoint:previousPoint2 withPreviousPoint:previousPoint1 withCurrentPoint:currentPoint];


### PR DESCRIPTION
The rectangle tool's behavior near the edge often leaves a pixel or two uncovered as the user's finger exits the touchscreen area (and touchesEnded registers a pixel or two from the edge).

This optional parameter allows the rectangle tool to snap to the edge with a configurable threshold (in px) - in practice I've found 15px is a generous value suitable for use by children.