### PR TITLE
Fix DraggableTextTool adjust bug.

### DIFF
--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -130,6 +130,7 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         self.labelTextField.tintColor = [UIColor redColor];
         self.labelTextField.textColor = [UIColor whiteColor];
         self.labelTextField.text = @"";
+        [self.labelTextField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
         
         self.border = [CAShapeLayer layer];
         self.border.strokeColor = self.borderColor.CGColor;
@@ -457,15 +458,15 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
     [textField adjustsWidthToFillItsContents];
 }
 
-- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
-{
+
+#pragma mark - UITextField UIControlEvent
+- (void)textFieldEditingChanged:(UITextField *)textField {
     if (!self.isShowingEditingHandles) {
         [self showEditingHandles];
     }
     [textField adjustsWidthToFillItsContents];
-    
-    return YES;
 }
+
 
 #pragma mark - Additional Properties
 


### PR DESCRIPTION
Hello guys, thank for good work.

DraggableTextTool has a bug in adjust size.

It happens when you enter the first letter after expanding.
![acedrawingview](https://user-images.githubusercontent.com/20692907/32694816-7d8f12c0-c78d-11e7-9806-1fe061d542a6.gif)

When ACEDrawingLabelView get text in UITextField at "shouldChangeCharactersInRange", it get the string before input, so it adjust the size with empty string.

Instead of that it need to use UIControlEventEditingChanged to get the latest string and adjust it properly.

![acedrawingviewfixed](https://user-images.githubusercontent.com/20692907/32694817-807a1700-c78d-11e7-9e3d-8e0f6af06515.gif)

