### PR TITLE
Fixing drawing of draggable text

### DIFF
--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -192,7 +192,7 @@
 
 - (UIImage *)applyDrawToImage:(UIImage *)baseImage
 {
-    UIImage *drawings = [self drawings];
+    UIImage *drawings = [self image];
     
     // scale drawings to size of base image
     drawings = (baseImage.size.width > baseImage.size.height) ? [self scaleImage:drawings proportionallyToWidth:baseImage.size.width] : [self scaleImage:drawings proportionallyToHeight:baseImage.size.height];


### PR DESCRIPTION
`- (UIImage *)applyDrawToImage:(UIImage *)baseImage` was not drawing  the draggable text views to the returned UIImage.