### PR TITLE
Make text tool label more configurable via ACEDrawingViewDelegate

### DIFF
--- a/ACEDrawingView/ACEDrawingLabelView.h
+++ b/ACEDrawingView/ACEDrawingLabelView.h
@@ -121,13 +121,6 @@
 @property (nonatomic, readonly) BOOL isEditing;
 
 /**
- *  Horizontal and vertical padding between inner text and selection box
- *
- *  Default: CGSize(12, 12)
- */
-@property (nonatomic, assign) CGSize globalInsets;
-
-/**
  *  Offset of the close button from the upper left corner
  *
  *  Default: CGPointZero

--- a/ACEDrawingView/ACEDrawingLabelView.h
+++ b/ACEDrawingView/ACEDrawingLabelView.h
@@ -24,6 +24,7 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <QuartzCore/QuartzCore.h>
 
 @protocol ACEDrawingLabelViewDelegate;
 
@@ -120,6 +121,81 @@
 @property (nonatomic, readonly) BOOL isEditing;
 
 /**
+ *  Horizontal and vertical padding between inner text and selection box
+ *
+ *  Default: CGSize(12, 12)
+ */
+@property (nonatomic, assign) CGSize globalInsets;
+
+/**
+ *  Offset of the close button from the upper left corner
+ *
+ *  Default: CGPointZero
+ */
+@property (nonatomic, assign) CGPoint closeButtonOffset;
+
+/**
+ *  Offset of the rotate button from the bottom right corner
+ *
+ *  Default: CGPointZero
+ */
+@property (nonatomic, assign) CGPoint rotateButtonOffset;
+
+/**
+ *  Size of the close button
+ *
+ *  Default: CGSize(24, 24)
+ */
+@property (nonatomic, assign) CGSize closeButtonSize;
+
+/**
+ *  Size of the rotate button
+ *
+ *  Default: CGSize(24, 24)
+ */
+@property (nonatomic, assign) CGSize rotateButtonSize;
+
+/**
+ *  UIButton instance for the close button so you can configure e.g. the corner
+ *  radius
+ */
+@property (nonatomic, readonly) UIButton *closeButton;
+
+/**
+ *  UIButton instance for the rotate button so you can configure e.g. the corner
+ *  radius
+ */
+@property (nonatomic, readonly) UIButton *rotateButton;
+
+/**
+ *  Layer shadow color
+ *
+ *  Default: UIColor.black
+ */
+@property (nonatomic, retain) UIColor *shadowColor;
+
+/**
+ *  Layer shadow offset
+ *
+ *  Default: CGSize(0, 5)
+ */
+@property (nonatomic, assign) CGSize shadowOffset;
+
+/**
+ *  Layer shadow opacity
+ *
+ *  Default: 1
+ */
+@property (nonatomic, assign) CGFloat shadowOpacity;
+
+/**
+ *  Layer shadow radius
+ *
+ *  Default: 4
+ */
+@property (nonatomic, assign) CGFloat shadowRadius;
+
+/**
  *  Hides border and control buttons.
  */
 - (void)hideEditingHandles;
@@ -142,9 +218,19 @@
 - (CGFloat)textAlpha;
 
 /**
- * Resizes content to fit rect
+ *  Resizes content to fit rect
  */
 - (void)resizeInRect:(CGRect)rect;
+
+/**
+ *  Internal
+ */
+- (void)beginEditing;
+
+/**
+ *  Internal
+ */
+- (void)applyLayout;
 
 @end
 
@@ -207,6 +293,14 @@
  *  @param label    A label object informing the delegate about action.
  */
 - (void)labelViewDidEndEditing:(ACEDrawingLabelView *)label;
+
+/**
+ *  Called just before a label is displayed. Configure values to make it look
+ *  the way you want.
+ *
+ *  @param label A label object informing the delegate about action.
+ */
+- (void)labelViewNeedsConfiguration:(ACEDrawingLabelView *)label;
 
 @end
 

--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -24,7 +24,6 @@
  */
 
 #import "ACEDrawingLabelView.h"
-#import <QuartzCore/QuartzCore.h>
 
 CG_INLINE CGPoint CGRectGetCenter(CGRect rect)
 {
@@ -56,8 +55,6 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
 }
 
 @interface ACEDrawingLabelView () <UIGestureRecognizerDelegate, UITextFieldDelegate>
-
-@property (nonatomic, assign) CGFloat globalInset;
 
 @property (nonatomic, assign) CGRect initialBounds;
 @property (nonatomic, assign) CGFloat initialDistance;
@@ -116,13 +113,23 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
     
     self = [super initWithFrame:frame];
     if (self) {
-        self.globalInset = 12;
+        self.labelTextField = [[UITextField alloc] initWithFrame:CGRectZero];
+        self.border = [CAShapeLayer layer];
+
+        _globalInsets = CGSizeMake(12, 12);
+        _closeButtonOffset = CGPointMake(0, 0);
+        _rotateButtonOffset = CGPointMake(0, 0);
+        _closeButtonSize = CGSizeMake(24, 24);
+        _rotateButtonSize = CGSizeMake(24, 24);
+        _shadowColor = [UIColor blackColor];
+        _shadowOffset = CGSizeMake(0, 5);
+        _shadowOpacity = 1;
+        _shadowRadius = 4;
         
         self.backgroundColor = [UIColor clearColor];
         [self setAutoresizingMask:(UIViewAutoresizingFlexibleHeight|UIViewAutoresizingFlexibleWidth)];
         self.borderColor = [UIColor redColor];
-        
-        self.labelTextField = [[UITextField alloc] initWithFrame:CGRectInset(self.bounds, self.globalInset, self.globalInset)];
+
         [self.labelTextField setAutoresizingMask:(UIViewAutoresizingFlexibleWidth|UIViewAutoresizingFlexibleHeight)];
         [self.labelTextField setClipsToBounds:YES];
         self.labelTextField.delegate = self;
@@ -131,28 +138,29 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         self.labelTextField.textColor = [UIColor whiteColor];
         self.labelTextField.text = @"";
         [self.labelTextField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
-        
-        self.border = [CAShapeLayer layer];
+
         self.border.strokeColor = self.borderColor.CGColor;
         self.border.fillColor = nil;
         self.border.lineDashPattern = @[@4, @3];
         
         [self insertSubview:self.labelTextField atIndex:0];
         
-        self.closeButton = [[UIButton alloc] initWithFrame:CGRectMake(0, 0, self.globalInset * 2, self.globalInset * 2)];
+        self.closeButton = [[UIButton alloc] initWithFrame:CGRectZero];
         [self.closeButton setAutoresizingMask:(UIViewAutoresizingFlexibleRightMargin|UIViewAutoresizingFlexibleBottomMargin)];
         self.closeButton.backgroundColor = [UIColor whiteColor];
-        self.closeButton.layer.cornerRadius = self.globalInset - 5;
+        self.closeButton.layer.cornerRadius = self.globalInsets.width - 5;
         self.closeButton.userInteractionEnabled = YES;
         [self addSubview:self.closeButton];
         
-        self.rotateButton = [[UIButton alloc] initWithFrame:CGRectMake(self.bounds.size.width-self.globalInset*2, self.bounds.size.height-self.globalInset*2, self.globalInset*2, self.globalInset*2)];
+        self.rotateButton = [[UIButton alloc] initWithFrame:CGRectZero];
         [self.rotateButton setAutoresizingMask:(UIViewAutoresizingFlexibleLeftMargin|UIViewAutoresizingFlexibleTopMargin)];
         self.rotateButton.backgroundColor = [UIColor whiteColor];
-        self.rotateButton.layer.cornerRadius = self.globalInset - 5;
+        self.rotateButton.layer.cornerRadius = self.globalInsets.width - 5;
         self.rotateButton.contentMode = UIViewContentModeCenter;
         self.rotateButton.userInteractionEnabled = YES;
         [self addSubview:self.rotateButton];
+
+        [self applyLayout];
         
         UIPanGestureRecognizer *moveGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(moveGesture:)];
         [self addGestureRecognizer:moveGesture];
@@ -165,7 +173,7 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         
         UIPanGestureRecognizer *panRotateGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(rotateViewPanGesture:)];
         [self.rotateButton addGestureRecognizer:panRotateGesture];
-        
+
         [moveGesture requireGestureRecognizerToFail:closeTap];
         
         [self setEnableMoveRestriction:NO];
@@ -174,7 +182,6 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         [self setShowsContentShadow:YES];
         
         [self showEditingHandles];
-        [self.labelTextField becomeFirstResponder];
     }
     return self;
 }
@@ -184,6 +191,38 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
     if (self.labelTextField) {
         self.border.path = [UIBezierPath bezierPathWithRect:self.labelTextField.bounds].CGPath;
         self.border.frame = self.labelTextField.bounds;
+    }
+}
+
+- (void)beginEditing
+{
+    [self.labelTextField becomeFirstResponder];
+}
+
+- (void)applyLayout
+{
+    _labelTextField.frame = CGRectInset(self.bounds, self.globalInsets.width, self.globalInsets.height);
+    _closeButton.frame = CGRectMake(self.closeButtonOffset.x, self.closeButtonOffset.y, self.closeButtonSize.width, self.closeButtonSize.height);
+    _rotateButton.frame = CGRectMake(
+                                     self.bounds.size.width - self.rotateButtonSize.width + self.rotateButtonOffset.x,
+                                     self.bounds.size.height - self.rotateButtonSize.height + self.rotateButtonOffset.y,
+                                     self.rotateButtonSize.width,
+                                     self.rotateButtonSize.height);
+    _labelTextField
+}
+
+- (void)updateShadow
+{
+    if (_showsContentShadow) {
+        [self.layer setShadowColor:self.shadowColor.CGColor];
+        [self.layer setShadowOffset:self.shadowOffset];
+        [self.layer setShadowOpacity:self.shadowOpacity];
+        [self.layer setShadowRadius:self.shadowRadius];
+    } else {
+        [self.layer setShadowColor:[UIColor clearColor].CGColor];
+        [self.layer setShadowOffset:CGSizeZero];
+        [self.layer setShadowOpacity:0.0];
+        [self.layer setShadowRadius:0.0];
     }
 }
 
@@ -203,21 +242,34 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
     [self.rotateButton setUserInteractionEnabled:_enableRotate];
 }
 
+- (void)setShadowColor:(UIColor *)shadowColor
+{
+    _shadowColor = shadowColor;
+    [self updateShadow];
+}
+
+- (void)setShadowOffset:(CGSize)shadowOffset
+{
+    _shadowOffset = shadowOffset;
+    [self updateShadow];
+}
+
+- (void)setShadowOpacity:(CGFloat)shadowOpacity
+{
+    _shadowOpacity = shadowOpacity;
+    [self updateShadow];
+}
+
+- (void)setShadowRadius:(CGFloat)shadowRadius
+{
+    _shadowRadius = shadowRadius;
+    [self updateShadow];
+}
+
 - (void)setShowsContentShadow:(BOOL)showShadow
 {
     _showsContentShadow = showShadow;
-    
-    if (_showsContentShadow) {
-        [self.layer setShadowColor:[UIColor blackColor].CGColor];
-        [self.layer setShadowOffset:CGSizeMake(0, 5)];
-        [self.layer setShadowOpacity:1.0];
-        [self.layer setShadowRadius:4.0];
-    } else {
-        [self.layer setShadowColor:[UIColor clearColor].CGColor];
-        [self.layer setShadowOffset:CGSizeZero];
-        [self.layer setShadowOpacity:0.0];
-        [self.layer setShadowRadius:0.0];
-    }
+    [self updateShadow];
 }
 
 - (void)setCloseImage:(UIImage *)image
@@ -421,9 +473,11 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         
         CGRect scaleRect = CGRectScale(self.initialBounds, scale, scale);
         
-        if (scaleRect.size.width >= (1+self.globalInset*2 + 20) && scaleRect.size.height >= (1+self.globalInset*2 + 20)) {
+        if (scaleRect.size.width >= (1+self.globalInsets.width*2 + 20) && scaleRect.size.height >= (1+self.globalInsets.height*2 + 20)) {
             if (self.fontSize < 100 || CGRectGetWidth(scaleRect) < CGRectGetWidth(self.bounds)) {
-                [self.labelTextField adjustsFontSizeToFillRect:scaleRect];
+                CGRect boundsCheckRect = scaleRect;
+                boundsCheckRect.size.width -= self.globalInsets.width * 2;
+                [self.labelTextField adjustsFontSizeToFillRect:boundsCheckRect];
                 [self setBounds:scaleRect];
             }
         }
@@ -499,7 +553,7 @@ static const NSUInteger ACELVMinimumFontSize = 9;
         NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text
                                                                              attributes:@{ NSFontAttributeName : font }];
         
-        CGRect rectSize = [attributedText boundingRectWithSize:CGSizeMake(CGRectGetWidth(newBounds)-24, CGFLOAT_MAX)
+        CGRect rectSize = [attributedText boundingRectWithSize:CGSizeMake(CGRectGetWidth(newBounds), CGFLOAT_MAX)
                                                        options:NSStringDrawingUsesLineFragmentOrigin
                                                        context:nil];
         

--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -118,8 +118,8 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         self.border = [CAShapeLayer layer];
 
         _globalInsets = CGSizeMake(12, 12);
-        _closeButtonOffset = CGPointMake(0, 0);
-        _rotateButtonOffset = CGPointMake(0, 0);
+        _closeButtonOffset = CGPointZero;
+        _rotateButtonOffset = CGPointZero;
         _closeButtonSize = CGSizeMake(24, 24);
         _rotateButtonSize = CGSizeMake(24, 24);
         _shadowColor = [UIColor blackColor];

--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -67,6 +67,7 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
 @property (nonatomic, assign) CGFloat deltaAngle;
 @property (nonatomic, assign) CGRect beginBounds;
 
+@property (nonatomic, assign) CGSize globalInsets;
 @property (nonatomic, strong) CAShapeLayer *border;
 @property (nonatomic, strong) UITextField *labelTextField;
 @property (nonatomic, strong) UIButton *rotateButton;
@@ -208,7 +209,6 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
                                      self.bounds.size.height - self.rotateButtonSize.height + self.rotateButtonOffset.y,
                                      self.rotateButtonSize.width,
                                      self.rotateButtonSize.height);
-    _labelTextField
 }
 
 - (void)updateShadow
@@ -568,7 +568,10 @@ static const NSUInteger ACELVMinimumFontSize = 9;
 {
     NSString *text = (![self.text isEqualToString:@""] || !self.placeholder) ? self.text : self.placeholder;
     UIFont *font = [UIFont fontWithName:self.font.fontName size:self.font.pointSize];
-    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:text
+    // Hotfix: despite exact text measurement, label text ends up clipped either on the beginning or the end.
+    // Inserting a couple extra characters here makes the end stick out awkwardly sometimes, but avoids the
+    // issue if you rotate the text.
+    NSAttributedString *attributedText = [[NSAttributedString alloc] initWithString:[text stringByAppendingString:@"xx"]
                                                                          attributes:@{ NSFontAttributeName : font }];
     
     CGRect rectSize = [attributedText boundingRectWithSize:CGSizeMake(CGFLOAT_MAX, CGRectGetHeight(self.frame)-24)

--- a/ACEDrawingView/ACEDrawingTools.m
+++ b/ACEDrawingView/ACEDrawingTools.m
@@ -210,19 +210,30 @@ CGPoint midPoint(CGPoint p1, CGPoint p2)
 - (void)setInitialPoint:(CGPoint)firstPoint
 {
     CGRect frame = CGRectMake(firstPoint.x, firstPoint.y, 50, 100);
-    
+
     _labelView = [[ACEDrawingLabelView alloc] initWithFrame:frame];
-    _labelView.delegate     = self.drawingView;
-    _labelView.fontSize     = 18.0;
-    _labelView.fontName     = self.drawingView.draggableTextFontName ?: [UIFont systemFontOfSize:_labelView.fontSize].fontName;
-    _labelView.textColor    = self.lineColor;
-    _labelView.closeImage   = self.drawingView.draggableTextCloseImage;
-    _labelView.rotateImage  = self.drawingView.draggableTextRotateImage;
+
+    [self configureLabelView];
+
+    [_labelView beginEditing];
 }
 
 - (void)moveFromPoint:(CGPoint)startPoint toPoint:(CGPoint)endPoint
 {
     // Not used for this tool
+}
+
+- (void)configureLabelView
+{
+    _labelView.delegate     = self.drawingView;
+    _labelView.fontSize     = 18.0;
+    _labelView.textColor    = self.lineColor;
+    _labelView.fontName     = self.drawingView.draggableTextFontName ?: [UIFont systemFontOfSize:_labelView.fontSize].fontName;
+    _labelView.closeImage   = self.drawingView.draggableTextCloseImage;
+    _labelView.rotateImage  = self.drawingView.draggableTextRotateImage;
+
+    [_labelView.delegate labelViewNeedsConfiguration:_labelView];
+    [_labelView applyLayout];
 }
 
 - (void)draw

--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -112,5 +112,6 @@ typedef NS_ENUM(NSUInteger, ACEDrawingMode) {
 - (void)drawingView:(ACEDrawingView *)view didEndDrawUsingTool:(id<ACEDrawingTool>)tool;
 - (void)drawingView:(ACEDrawingView *)view didRedoDrawUsingTool:(id<ACEDrawingTool>)tool;
 - (void)drawingView:(ACEDrawingView *)view didUndoDrawUsingTool:(id<ACEDrawingTool>)tool;
+- (void)drawingView:(ACEDrawingView *)view configureTextToolLabelView:(ACEDrawingLabelView *)label;
 
 @end

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -318,7 +318,7 @@
     
     // Handle special cases for tool types. The else case handles all the non-text drawing tools.
     // The draggable text tool is purposely left in for better code clarity, even though it does nothing.
-    if ([self.currentTool class] == [ACEDrawingDraggableTextTool class]) {
+    if ([self.currentTool isKindOfClass: [ACEDrawingDraggableTextTool class]]) {
         // do nothing
         
     } else {

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -490,7 +490,8 @@
 
 - (void)hideTextToolHandles
 {
-    for (id<ACEDrawingTool> tool in self.pathArray) {
+    NSArray *pathArrayCopy = [self.pathArray copy];  // Avoid runtime error when mutating collection
+    for (id<ACEDrawingTool> tool in pathArrayCopy) {
         if ([tool isKindOfClass:[ACEDrawingDraggableTextTool class]]) {
             [(ACEDrawingDraggableTextTool *)tool hideHandle];
         }

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -678,6 +678,13 @@
     return nil;
 }
 
+- (void)labelViewNeedsConfiguration:(ACEDrawingLabelView *)label
+{
+    if ([self.delegate respondsToSelector:@selector(drawingView:configureTextToolLabelView:)]) {
+        [self.delegate drawingView:self configureTextToolLabelView:label];
+    }
+}
+
 #pragma mark Image Utilities
 
 - (UIImage*)scaleImage:(UIImage *)sourceImage proportionallyToWidth:(CGFloat)width

--- a/ACEDrawingViewDemo/ACEViewController.m
+++ b/ACEDrawingViewDemo/ACEViewController.m
@@ -126,6 +126,15 @@
     [self updateButtonStatus];
 }
 
+- (void)drawingView:(ACEDrawingView *)view configureTextToolLabelView:(ACEDrawingLabelView *)label;
+{
+    label.shadowOffset = CGSizeMake(0, 1);
+    label.shadowOpacity = 0.5;
+    label.shadowRadius = 1;
+    label.closeButtonOffset = CGPointMake(-6, -6);
+    label.rotateButtonOffset = CGPointMake(6, 6);
+}
+
 
 #pragma mark - Action Sheet Delegate
 

--- a/ACEDrawingViewDemo/ACEViewController.m
+++ b/ACEDrawingViewDemo/ACEViewController.m
@@ -128,6 +128,8 @@
 
 - (void)drawingView:(ACEDrawingView *)view configureTextToolLabelView:(ACEDrawingLabelView *)label;
 {
+    // If you don't like the default text control styles, you can tweak them
+    // in this delegate method.
     label.shadowOffset = CGSizeMake(0, 1);
     label.shadowOpacity = 0.5;
     label.shadowRadius = 1;


### PR DESCRIPTION
Some people (i.e. me) want to customize several aspects of ACEDrawingLabelView which are not currently exposed to users of the framework. This PR makes the changes necessary to enable that customization.

1. `ACEDrawingLabelView` has new configurable properties that replace previously hard-coded values:
  * `[close|rotate]ButtonOffset`
  * `[close|rotate]ButtonSize`
  * `[close|rotate]Button`
  * `shadow[Color|Opacity|Radius|Offset]`
2. `ACEDrawingViewDelegate` has a new optional method which allows the delegate to configure those properties before the label is displayed: `[delegate labelViewNeedsConfiguration:label]`
3. Demonstrate usage in the demo app
4. Add a hotfix for incorrect text metrics
5. Add fix for crash when adding more than one text object at a time
6. Fix incorrect class conformance check which triggered number 5 above