### PR TITLE
Text tool Return key is now 'Done'; Done button ends editing

### DIFF
--- a/ACEDrawingView/ACEDrawingLabelView.h
+++ b/ACEDrawingView/ACEDrawingLabelView.h
@@ -288,6 +288,13 @@
 - (void)labelViewDidEndEditing:(ACEDrawingLabelView *)label;
 
 /**
+ *  Occurs when the user taps the Done button while entering text.
+ *
+ *  @param label    A label object informing the delegate about action.
+ */
+- (void)labelViewDidReturn:(ACEDrawingLabelView *)label;
+
+/**
  *  Called just before a label is displayed. Configure values to make it look
  *  the way you want.
  *

--- a/ACEDrawingView/ACEDrawingLabelView.m
+++ b/ACEDrawingView/ACEDrawingLabelView.m
@@ -138,6 +138,7 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
         self.labelTextField.tintColor = [UIColor redColor];
         self.labelTextField.textColor = [UIColor whiteColor];
         self.labelTextField.text = @"";
+        self.labelTextField.returnKeyType = UIReturnKeyDone;
         [self.labelTextField addTarget:self action:@selector(textFieldEditingChanged:) forControlEvents:UIControlEventEditingChanged];
 
         self.border.strokeColor = self.borderColor.CGColor;
@@ -510,6 +511,14 @@ CG_INLINE CGSize CGAffineTransformGetScale(CGAffineTransform t)
     }
     
     [textField adjustsWidthToFillItsContents];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField
+{
+    if ([self.delegate respondsToSelector:@selector(labelViewDidReturn:)]) {
+        [self.delegate labelViewDidReturn:self];
+    }
+    return NO;
 }
 
 

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -667,6 +667,11 @@
     }
 }
 
+- (void)labelViewDidReturn:(ACEDrawingLabelView *)label
+{
+    [self.draggableTextView hideEditingHandles];
+}
+
 - (ACEDrawingDraggableTextTool *)draggableTextToolForLabel:(ACEDrawingLabelView *)label
 {
     for (id<ACEDrawingTool> tool in self.pathArray) {


### PR DESCRIPTION
The Return key formerly did nothing, as far as I could tell. Now it closes the keyboard.