### PR TITLE
fix cache image displacement with ACEDrawingModeScale

### DIFF
--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -166,8 +166,16 @@
         }
         
     } else {
-        // set the draw point
-        [self.cacheImage drawAtPoint:CGPointZero];
+        // scale if needed (may be view's size is changed)
+        switch (self.drawMode) {
+            case ACEDrawingModeOriginalSize:
+                [self.cacheImage drawAtPoint:CGPointZero];
+                break;
+                
+            case ACEDrawingModeScale:
+                [self.cacheImage drawInRect:self.bounds];
+                break;
+        }
         [self.currentTool draw];
     }
     


### PR DESCRIPTION
If view's size is changed after loading image(for example, you load image at viewDidLoad, then it's frame is updated by auto layout), the cache image will be drawn at CGPointZero, which leads to cache image displacement.