### PR TITLE
Update .travis.yml to newest Xcode and iPhone Simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.2
+osx_image: xcode11.6
 xcode_workspace: ACEDrawingViewDemo.xcworkspace
 xcode_scheme: ACEDrawingViewDemo
-xcode_sdk: iphonesimulator9.3
+xcode_sdk: iphonesimulator13.6


### PR DESCRIPTION
The current configuration fails due to not being able to locate the simulator: `xcodebuild: error: SDK "iphonesimulator9.3" cannot be located.`.

According to the docs ([docs.travis-ci.com/user/reference/osx#xcode-73](https://docs.travis-ci.com/user/reference/osx#xcode-73)) it should still work but using a more recent version of Xcode is a good idea anyways.