### PR TITLE
Update podfile and CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ osx_image: xcode11.6
 xcode_workspace: ACEDrawingViewDemo.xcworkspace
 xcode_scheme: ACEDrawingViewDemo
 xcode_destination: platform=iOS Simulator,OS=13.6,name=iPhone 11
-xcode_sdk: iphonesimulator13.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: objective-c
 osx_image: xcode11.6
 xcode_workspace: ACEDrawingViewDemo.xcworkspace
 xcode_scheme: ACEDrawingViewDemo
+xcode_destination: platform=iOS Simulator,OS=13.6,name=iPhone 11
 xcode_sdk: iphonesimulator13.6

--- a/ACEDrawingView.podspec
+++ b/ACEDrawingView.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Stefano Acerbetti' => 'acerbetti@gmail.com' }
   s.source       = { :git => 'https://github.com/acerbetti/ACEDrawingView.git', :tag => 'v2.2.1' }
   s.frameworks   = 'QuartzCore'
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '8.0'
   s.source_files = 'ACEDrawingView/*.{h,m}'
   s.resource_bundles = {
     'ACEDraggableText' => ['ACEDrawingView/ACEDraggableText/*.png'],

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '7.0'
+platform :ios, '8.0'
 
 target 'ACEDrawingViewDemo' do
   pod 'ACEDrawingView', :path => './'


### PR DESCRIPTION
CI is still failing with this error: `The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 7.0, but the range of supported deployment target versions is 8.0 to 13.6.99. (in target 'ACEDrawingView' from project 'Pods')`.

Updating the deployment target should fix it.