### PR TITLE
Add SwiftPM and Github actions support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,71 @@
+name: "ACEDrawingView CI"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  Example:
+    name: Example Project (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod install
+        run: pod install
+
+      - name: Build Project
+        uses: sersoft-gmbh/xcodebuild-action@v1.8.0
+        with:
+          workspace: ACEDrawingViewDemo.xcworkspace
+          scheme: ACEDrawingViewDemo
+          destination: name=iPhone 13 Pro
+          action: test
+          
+  Pods:
+    name: Cocoapods Lint (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable
+
+      - name: Run pod lib lint dynamic-framework
+        run: pod lib lint --allow-warnings --fail-fast
+
+      - name: Run pod lib lint static-framework
+        run: pod lib lint --allow-warnings --fail-fast --use-libraries --use-modular-headers
+          
+  SwiftPM:
+    name: SwiftPM (Latest Stable Xcode)
+    runs-on: macOS-11
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.4.0
+        with: 
+          xcode-version: latest-stable 
+
+      - name: Build
+        run: | # Move projects files temporarily to avoid interfering with SwiftPM build.
+          mv "ACEDrawingViewDemo.xcodeproj" "ACEDrawingViewDemo.xcodeproj_temp"
+          mv "ACEDrawingViewDemo.xcworkspace" "ACEDrawingViewDemo.xcworkspace_temp"
+          xcodebuild -scheme ACEDrawingView -destination generic/platform=iOS
+          mv "ACEDrawingViewDemo.xcodeproj_temp" "ACEDrawingViewDemo.xcodeproj"
+          mv "ACEDrawingViewDemo.xcworkspace_temp" "ACEDrawingViewDemo.xcworkspace"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: objective-c
-osx_image: xcode11.6
-xcode_workspace: ACEDrawingViewDemo.xcworkspace
-xcode_scheme: ACEDrawingViewDemo
-xcode_sdk: iphonesimulator13.6

--- a/ACEDrawingView.podspec
+++ b/ACEDrawingView.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = 'ACEDrawingView'
-  s.version      = '2.2.1'
+  s.version      = '2.3.0'
   s.license      = { :type => 'Apache 2.0 License', :file => 'LICENSE.txt' }
   s.summary      = 'An open source iOS component to create a drawing app.'
   s.homepage     = 'https://github.com/acerbetti/ACEDrawingView'
   s.author       = { 'Stefano Acerbetti' => 'acerbetti@gmail.com' }
-  s.source       = { :git => 'https://github.com/acerbetti/ACEDrawingView.git', :tag => 'v2.2.1' }
+  s.source       = { :git => 'https://github.com/acerbetti/ACEDrawingView.git', :tag => s.version.to_s }
   s.frameworks   = 'QuartzCore'
   s.platform     = :ios, '7.0'
   s.source_files = 'ACEDrawingView/*.{h,m}'

--- a/ACEDrawingView/ACEDrawingView.m
+++ b/ACEDrawingView/ACEDrawingView.m
@@ -96,7 +96,12 @@
     self.backgroundColor = [UIColor clearColor];
     
     // set the deafault draggable text icons
-    NSURL *bundleURL = [[NSBundle bundleForClass:self.classForCoder] URLForResource:@"ACEDraggableText" withExtension:@"bundle"];
+#ifdef SWIFT_PACKAGE
+    NSString *resourceName = @"ACEDrawingView_ACEDrawingView";
+#else
+    NSString *resourceName = @"ACEDraggableText";
+#endif
+    NSURL *bundleURL = [[NSBundle bundleForClass:self.classForCoder] URLForResource:resourceName withExtension:@"bundle"];
     if (bundleURL != nil) {
         self.draggableTextRotateImage = [UIImage imageWithContentsOfFile:[[NSBundle bundleWithURL:bundleURL] pathForResource:@"sticker_resize" ofType:@"png"]];
         self.draggableTextCloseImage  = [UIImage imageWithContentsOfFile:[[NSBundle bundleWithURL:bundleURL] pathForResource:@"sticker_close" ofType:@"png"]];

--- a/ACEDrawingView/include/ACEDrawingLabelView.h
+++ b/ACEDrawingView/include/ACEDrawingLabelView.h
@@ -1,0 +1,1 @@
+../ACEDrawingLabelView.h

--- a/ACEDrawingView/include/ACEDrawingToolState.h
+++ b/ACEDrawingView/include/ACEDrawingToolState.h
@@ -1,0 +1,1 @@
+../ACEDrawingToolState.h

--- a/ACEDrawingView/include/ACEDrawingTools.h
+++ b/ACEDrawingView/include/ACEDrawingTools.h
@@ -1,0 +1,1 @@
+../ACEDrawingTools.h

--- a/ACEDrawingView/include/ACEDrawingView.h
+++ b/ACEDrawingView/include/ACEDrawingView.h
@@ -1,0 +1,1 @@
+../ACEDrawingView.h

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "ACEDrawingView",
+    platforms: [
+        .iOS(.v9),
+    ],
+    products: [
+        .library(
+            name: "ACEDrawingView",
+            targets: ["ACEDrawingView"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "ACEDrawingView",
+            path: "ACEDrawingView",
+            resources: [.process("ACEDraggableText")]),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-ACEDrawingView [![Build Status](https://travis-ci.org/acerbetti/ACEDrawingView.svg?branch=master)](https://travis-ci.org/acerbetti/ACEDrawingView) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ACEDrawingView.svg)](http://cocoadocs.org/docsets/ACEDrawingView) [![Platform](https://img.shields.io/cocoapods/p/ACEDrawingView.svg?style=flat)](http://cocoadocs.org/docsets/ACEDrawingView)
+ACEDrawingView [![Build Status](https://github.com/acerbetti/ACEDrawingView/workflows/ACEDrawingView%20CI/badge.svg?branch=master)](https://github.com/acerbetti/ACEDrawingView/actions) [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/apple/swift-package-manager) [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/ACEDrawingView.svg)](http://cocoadocs.org/docsets/ACEDrawingView) [![Platform](https://img.shields.io/cocoapods/p/ACEDrawingView.svg?style=flat)](http://cocoadocs.org/docsets/ACEDrawingView)
 ==============
 
 ![](https://github.com/acerbetti/ACEDrawingView/blob/master/Example.png?raw=true)      ![](https://github.com/deviserRahul/ACEDrawingView/blob/master/Example2.png?raw=true)
@@ -19,6 +19,10 @@ How-To
 
 1. Add `pod 'ACEDrawingView'` to your Podfile.
 2. Run `pod install`
+
+### SwiftPM
+
+Add `.package(url: "https://github.com/acerbetti/ACEDrawingView.git", from: "2.3.0")` to your `package.swift`
 
 
 Features


### PR DESCRIPTION
* Add a SwiftPM manifest file
* Bump version to 2.3.0
* Update the .gitignore file to ignore local swiftpm artifacts
* Replace travis-ci with Github actions for continuous integration as travis-ci.org has ceased. Actions will take into affect immediately as shown on my fork: https://github.com/master-nevi/ACEDrawingView/actions
* Used symbolic links to make the public interface SwiftPM friendly. While an actual directory restructure (without symlinks) would have worked also, the changes would have been more significant and I would sooner leave that level of restructuring to a dedicated developer of this library.
* Update README badge