### PR TITLE
Fix access to public types in Swift Package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: objective-c
-osx_image: xcode11.6
-xcode_workspace: ACEDrawingViewDemo.xcworkspace
-xcode_scheme: ACEDrawingViewDemo
-xcode_destination: platform=iOS Simulator,OS=13.6,name=iPhone 11

--- a/ACEDrawingView.podspec
+++ b/ACEDrawingView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'ACEDrawingView'
-  s.version      = '2.3.0'
+  s.version      = '2.4.1'
   s.license      = { :type => 'Apache 2.0 License', :file => 'LICENSE.txt' }
   s.summary      = 'An open source iOS component to create a drawing app.'
   s.homepage     = 'https://github.com/acerbetti/ACEDrawingView'

--- a/ACEDrawingView/ACEDrawingView.h
+++ b/ACEDrawingView/ACEDrawingView.h
@@ -24,7 +24,13 @@
  */
 
 #import <UIKit/UIKit.h>
+
+/**
+ Swift Package Manager uses this header as the umbrella header. Therefore import all public headers here.
+ */
 #import "ACEDrawingLabelView.h"
+#import "ACEDrawingTools.h"
+#import "ACEDrawingToolState.h"
 
 #define ACEDrawingViewVersion   2.0.1
 


### PR DESCRIPTION
* Swift Package Manager will not auto-generate an umbrella header if one with the format `<spm_target>.h` exists. In this case, because `ACEDrawingView.h` exists, it serves as the umbrella header and must import all the public headers.

* Remove `.travis.yaml` as Travis-CI is now a paid service: 
  * Previously I added support for Github Actions which serves as continuous integration and is free.
    ![Screen Shot 2022-10-21 at 11 02 14 AM](https://user-images.githubusercontent.com/987706/197260351-4500345d-9a45-424e-a21f-5f20d38a4e9e.png)
  * Github actions: 
     ![Screen Shot 2022-10-21 at 11 03 17 AM](https://user-images.githubusercontent.com/987706/197260492-db2da66b-11d4-4ab8-89d6-63fe9060935f.png)
